### PR TITLE
Changed skillet names to follow best practices of lowercase naming

### DIFF
--- a/panorama/.meta-cnc.yaml
+++ b/panorama/.meta-cnc.yaml
@@ -1,7 +1,7 @@
 # skillet preamble information used by panhandler
 # ---------------------------------------------------------------------
 # unique snippet name
-name: NetSecOpenSkillet_panorama
+name: net_sec_open_panorama
 # label used for menu selection
 label: NetSecOpen_panorama_label
 description: Skillet for NetSecOpen configuration

--- a/panos/.meta-cnc.yaml
+++ b/panos/.meta-cnc.yaml
@@ -1,7 +1,7 @@
 # skillet preamble information used by panhandler
 # ---------------------------------------------------------------------
 # unique snippet name
-name: net_sec_open-panos
+name: net_sec_open_panos
 # label used for menu selection
 label: NetSecOpen_label
 description: Skillet for NetSecOpen configuration

--- a/panos/.meta-cnc.yaml
+++ b/panos/.meta-cnc.yaml
@@ -1,7 +1,7 @@
 # skillet preamble information used by panhandler
 # ---------------------------------------------------------------------
 # unique snippet name
-name: NetSecOpenSkillet-panos
+name: net_sec_open-panos
 # label used for menu selection
 label: NetSecOpen_label
 description: Skillet for NetSecOpen configuration


### PR DESCRIPTION
## Description
Changed both the panos and panorama skillet names to all lowercase with underscores.  This is part of the naming convention used for skillets.  Nothing else changed and the user never sees this.  The standardization is for making it more programmable

## Motivation and Context
Standards and best practices
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in my own fork and verified that no functionality changed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes
Just changes to skillet names within their respective .meta-cnc.yml files
<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
